### PR TITLE
fix(auth): redirect to login on expired JWT token (issue #43)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,8 +9,8 @@
     },
     {
       "name": "backend",
-      "runtimeExecutable": "npx",
-      "runtimeArgs": ["nx", "serve", "backend"],
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "npx nx build backend --configuration=development && node dist/apps/backend/main.js"],
       "port": 3000
     }
   ]

--- a/apps/backend/webpack.config.js
+++ b/apps/backend/webpack.config.js
@@ -1,5 +1,6 @@
 const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 const { join } = require('path');
+const webpack = require('webpack');
 
 module.exports = {
   output: {
@@ -10,6 +11,10 @@ module.exports = {
     }),
   },
   plugins: [
+    new webpack.IgnorePlugin({ resourceRegExp: /^@nestjs\/microservices$/ }),
+    new webpack.IgnorePlugin({ resourceRegExp: /^@nestjs\/microservices\/microservices-module$/ }),
+    new webpack.IgnorePlugin({ resourceRegExp: /^@nestjs\/websockets$/ }),
+    new webpack.IgnorePlugin({ resourceRegExp: /^@nestjs\/websockets\/socket-module$/ }),
     new NxAppWebpackPlugin({
       target: 'node',
       compiler: 'tsc',

--- a/apps/frontend/src/app/interceptors/auth.interceptor.spec.ts
+++ b/apps/frontend/src/app/interceptors/auth.interceptor.spec.ts
@@ -4,6 +4,8 @@ import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { authInterceptor } from './auth.interceptor';
 import { AuthService } from '../services/auth.service';
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
@@ -12,17 +14,25 @@ describe('authInterceptor', () => {
   let httpMock: HttpTestingController;
   let httpClient: HttpClient;
   let mockAuthService: any;
+  let mockRouter: any;
 
   beforeEach(() => {
     mockAuthService = {
       getToken: vi.fn(),
+      logout: vi.fn(),
+    };
+
+    mockRouter = {
+      navigate: vi.fn(),
     };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: AuthService, useValue: mockAuthService },
+        { provide: Router, useValue: mockRouter },
         provideHttpClient(withInterceptors([authInterceptor])),
         provideHttpClientTesting(),
+        provideRouter([]),
       ],
     });
 
@@ -108,5 +118,83 @@ describe('authInterceptor', () => {
     expect(req.request).toBeTruthy();
 
     req.flush({});
+  });
+
+  it('should call logout and navigate to /login on 401 response', () => {
+    mockAuthService.getToken.mockReturnValue('expired-token');
+
+    let errorReceived: any;
+    httpClient.get('/api/test').subscribe({
+      error: (err) => (errorReceived = err),
+    });
+
+    const req = httpMock.expectOne('/api/test');
+    req.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(mockAuthService.logout).toHaveBeenCalled();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/login']);
+    expect(errorReceived.status).toBe(401);
+  });
+
+  it('should not logout on non-401 errors', () => {
+    mockAuthService.getToken.mockReturnValue('valid-token');
+
+    let errorReceived: any;
+    httpClient.get('/api/test').subscribe({
+      error: (err) => (errorReceived = err),
+    });
+
+    const req = httpMock.expectOne('/api/test');
+    req.flush({ message: 'Server Error' }, { status: 500, statusText: 'Internal Server Error' });
+
+    expect(mockAuthService.logout).not.toHaveBeenCalled();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(errorReceived.status).toBe(500);
+  });
+
+  it('should not logout on 403 errors', () => {
+    mockAuthService.getToken.mockReturnValue('valid-token');
+
+    let errorReceived: any;
+    httpClient.get('/api/test').subscribe({
+      error: (err) => (errorReceived = err),
+    });
+
+    const req = httpMock.expectOne('/api/test');
+    req.flush({ message: 'Forbidden' }, { status: 403, statusText: 'Forbidden' });
+
+    expect(mockAuthService.logout).not.toHaveBeenCalled();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(errorReceived.status).toBe(403);
+  });
+
+  it('should propagate 401 error to subscriber even after logout', () => {
+    mockAuthService.getToken.mockReturnValue('expired-token');
+
+    let errorReceived: any;
+    httpClient.get('/api/test').subscribe({
+      error: (err) => (errorReceived = err),
+    });
+
+    const req = httpMock.expectOne('/api/test');
+    req.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    expect(errorReceived).toBeTruthy();
+    expect(errorReceived.status).toBe(401);
+  });
+
+  it('should not handle 401 for non-/api requests (no token injection)', () => {
+    mockAuthService.getToken.mockReturnValue('valid-token');
+
+    httpClient.get('/other/endpoint').subscribe({
+      error: () => {},
+    });
+
+    const req = httpMock.expectOne('/other/endpoint');
+    req.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    // Non-/api requests go through next(req) without error handling
+    expect(mockAuthService.logout).not.toHaveBeenCalled();
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/interceptors/auth.interceptor.ts
+++ b/apps/frontend/src/app/interceptors/auth.interceptor.ts
@@ -1,9 +1,12 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const authService = inject(AuthService);
+  const router = inject(Router);
   const token = authService.getToken();
 
   if (token && req.url.startsWith('/api')) {
@@ -12,7 +15,15 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
         Authorization: `Bearer ${token}`,
       },
     });
-    return next(cloned);
+    return next(cloned).pipe(
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 401) {
+          authService.logout();
+          router.navigate(['/login']);
+        }
+        return throwError(() => error);
+      })
+    );
   }
 
   return next(req);


### PR DESCRIPTION
## Problème (issue #43)

Après expiration du token JWT (7 jours), l'interface ne demandait pas de ré-authentification mais ne pouvait plus se connecter au backend. Les requêtes API retournaient silencieusement 401 sans redirection.

## Cause racine

`auth.interceptor.ts` injectait le token dans les requêtes mais n'avait **aucune gestion des erreurs HTTP**. En cas de 401, rien ne se passait côté frontend.

## Corrections

### `apps/frontend/src/app/interceptors/auth.interceptor.ts`
- Ajout d'un `catchError` sur les requêtes authentifiées (`/api/*`)
- En cas de **401** : appel de `authService.logout()` (efface localStorage + reset signaux) puis navigation vers `/login`
- Les autres erreurs (403, 500…) sont propagées normalement sans déconnexion

### `apps/frontend/src/app/interceptors/auth.interceptor.spec.ts`
5 tests ajoutés :
- ✅ 401 → `logout()` appelé + navigation vers `/login`
- ✅ 500 → pas de logout
- ✅ 403 → pas de logout
- ✅ L'erreur 401 est propagée au subscriber
- ✅ Les requêtes hors `/api` ne sont pas affectées

### `apps/backend/webpack.config.js`
- Ajout de `webpack.IgnorePlugin` pour les dépendances optionnelles NestJS (`@nestjs/microservices`, `@nestjs/websockets`) qui causaient des erreurs de build

### `.claude/launch.json`
- Mise à jour de la config backend pour builder avant de servir

## Tests

- Frontend : **241 ✓ / 3 skipped** (skips pré-existants issue #34)
- Backend : **151 ✓**

## Vérification E2E

Scénario testé manuellement :
1. Connexion → redirigé vers `/routines` ✅
2. Token expiré injecté en localStorage
3. Navigation vers `/routines` → backend retourne 401
4. Interceptor détecte le 401 → `logout()` → token effacé → redirection `/login` ✅

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)