### PR TITLE
chore(ci): update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -56,12 +56,12 @@ jobs:
     # steps to perform in job
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{env.APP_PATH}}
 
       - name: Checkout gitops
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ env.actions_token != '' }}
         with:
           repository: bibulle/myKubernetesConfig
@@ -93,11 +93,11 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         id: login_dockerhub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: ${{ env.dockerhub_username != '' && env.dockerhub_password != '' }}
         with:
           username: ${{ env.dockerhub_username }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ${{env.APP_PATH}}
           push: ${{ env.dockerhub_username != '' && env.dockerhub_password != '' }}


### PR DESCRIPTION
## Summary
- Update all GitHub Actions to versions compatible with Node.js 24
- Fixes the deprecation warning: *"Node.js 20 actions are deprecated"*

## Changes
| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v3` | `@v4` |
| `actions/setup-node` | `@v3` | `@v4` |
| `docker/setup-buildx-action` | `@v2` | `@v3` |
| `docker/login-action` | `@v2` | `@v3` |
| `docker/build-push-action` | `@v3` | `@v6` |

## Context
GitHub will force Node.js 24 as default starting **June 2, 2026**. These updates ensure the CI/CD pipeline continues working without issues.

## Test plan
- [x] No functional changes, only version bumps
- [x] CI will validate on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)