### PR TITLE
fix(csp): corriger les inline event handlers bloqués en production

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -25,8 +25,12 @@ async function bootstrap() {
         ...helmet.contentSecurityPolicy.getDefaultDirectives(),
         // Allow Google profile pictures from OAuth
         'img-src': ["'self'", 'data:', 'https://lh3.googleusercontent.com'],
-        // Allow inline event handlers (needed for Angular event bindings)
-        'script-src-attr': null,
+        // Allow Google Fonts
+        'style-src': ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
+        'font-src': ["'self'", 'https://fonts.gstatic.com'],
+        // Angular event bindings compile to addEventListener, not inline handlers.
+        // However Zone.js and some browser APIs require this to be explicitly set.
+        'script-src-attr': ["'unsafe-inline'"],
       },
     } : false,
   }));


### PR DESCRIPTION
## Problème

En production, l'erreur suivante apparaissait dans la console :

> Executing inline event handler violates the following Content Security Policy directive 'script-src 'self''. Either the 'unsafe-inline' keyword, a hash, or a nonce is required.

## Cause

Dans `apps/backend/src/main.ts`, la directive Helmet était configurée avec `'script-src-attr': null`. En Helmet, `null` **supprime** la directive du header CSP — le navigateur fait alors fallback sur `script-src: 'self'` qui ne contient pas `'unsafe-inline'`, donc les inline event handlers sont bloqués. C'est l'inverse de l'intention du commentaire original.

## Correction

- `'script-src-attr': ["'unsafe-inline'"]` → autorise explicitement les event handlers inline (Zone.js, Angular) sans assouplir `script-src` pour les scripts chargés
- `'style-src'` étendu avec `fonts.googleapis.com` → évite le blocage des Google Fonts
- `'font-src'` ajouté avec `fonts.gstatic.com` → idem pour les fichiers de polices

## Tests

- 165 tests backend ✅
- 316 tests frontend ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)