### PR TITLE
feat(routines): ajouter champ tag/catégorie — close #90

### DIFF
--- a/apps/backend/src/routines/dto/create-routine.dto.ts
+++ b/apps/backend/src/routines/dto/create-routine.dto.ts
@@ -60,6 +60,11 @@ export class CreateRoutineDto {
   @IsOptional()
   @IsString()
   @MaxLength(50)
+  tag?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
   category?: string;
 
   @IsOptional()

--- a/apps/backend/src/routines/dto/update-routine.dto.ts
+++ b/apps/backend/src/routines/dto/update-routine.dto.ts
@@ -61,6 +61,11 @@ export class UpdateRoutineDto {
   @IsOptional()
   @IsString()
   @MaxLength(50)
+  tag?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
   category?: string;
 
   @IsOptional()

--- a/apps/backend/src/schemas/routine.schema.ts
+++ b/apps/backend/src/schemas/routine.schema.ts
@@ -63,6 +63,9 @@ export class Routine {
 
   @Prop()
   ownerId?: string;
+
+  @Prop()
+  tag?: string;
 }
 
 export const RoutineSchema = SchemaFactory.createForClass(Routine);

--- a/apps/backend/src/scripts/migrate-routine-tags.ts
+++ b/apps/backend/src/scripts/migrate-routine-tags.ts
@@ -1,0 +1,50 @@
+import mongoose from 'mongoose';
+
+const TAG_MAP: Record<string, string> = {
+  'douce-10min':  'quotidien',
+  'bureau-5min':  'bureau',
+};
+
+const KEYWORD_TAGS: Array<{ keywords: string[]; tag: string }> = [
+  { keywords: ['squash', 'golf', 'running', 'sport', 'ischio', 'gainage'], tag: 'sport' },
+  { keywords: ['bureau', 'cervical', 'assis', 'travail', 'express'],       tag: 'bureau' },
+  { keywords: ['respiration', 'sophrologie', 'cohérence'],                  tag: 'respiration' },
+  { keywords: ['mobilité', 'mobilite', 'étirement', 'yoga'],               tag: 'mobilite' },
+  { keywords: ['quotidien', 'matin', 'soir', 'réveil', 'douce'],          tag: 'quotidien' },
+];
+
+function inferTag(routine: { id: string; name: string; description?: string }): string | null {
+  if (TAG_MAP[routine.id]) return TAG_MAP[routine.id];
+  const text = `${routine.name} ${routine.description ?? ''}`.toLowerCase();
+  for (const { keywords, tag } of KEYWORD_TAGS) {
+    if (keywords.some(kw => text.includes(kw))) return tag;
+  }
+  return null;
+}
+
+async function migrateRoutineTags() {
+  const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/flexicoach';
+  await mongoose.connect(mongoUri);
+  console.log('✅ Connected to MongoDB');
+
+  const col = mongoose.connection.db.collection('routines');
+  const routines = await col.find({}).toArray();
+
+  let updated = 0;
+  for (const routine of routines) {
+    if (routine.tag) continue; // already tagged
+    const tag = inferTag(routine as any);
+    if (tag) {
+      await col.updateOne({ _id: routine._id }, { $set: { tag } });
+      console.log(`  ✓ ${routine.name} → ${tag}`);
+      updated++;
+    } else {
+      console.log(`  ⚠️  ${routine.name} → no tag inferred`);
+    }
+  }
+
+  console.log(`\n✨ Tagged ${updated}/${routines.length} routines`);
+  await mongoose.disconnect();
+}
+
+migrateRoutineTags().catch(err => { console.error(err); process.exit(1); });

--- a/apps/frontend/src/app/components/routine-editor.component.html
+++ b/apps/frontend/src/app/components/routine-editor.component.html
@@ -61,6 +61,17 @@
             </select>
           </div>
           <div class="editor-pill">
+            <span class="pill-label">Tag</span>
+            <select formControlName="tag" class="pill-select">
+              <option value="">—</option>
+              <option value="quotidien">Quotidien</option>
+              <option value="bureau">Bureau</option>
+              <option value="sport">Sport</option>
+              <option value="mobilite">Mobilité</option>
+              <option value="respiration">Respiration</option>
+            </select>
+          </div>
+          <div class="editor-pill">
             <span class="pill-label">Catégorie</span>
             <input formControlName="category" class="pill-input" placeholder="ex: squash" />
           </div>

--- a/apps/frontend/src/app/components/routine-editor.component.ts
+++ b/apps/frontend/src/app/components/routine-editor.component.ts
@@ -46,6 +46,7 @@ export class RoutineEditorComponent implements OnInit {
     this.routineForm = this.fb.group({
       name: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(50)]],
       description: ['', Validators.maxLength(500)],
+      tag: [''],
       category: ['', Validators.maxLength(50)],
       difficulty: ['beginner', Validators.required],
       icon: ['', Validators.maxLength(50)],
@@ -75,6 +76,7 @@ export class RoutineEditorComponent implements OnInit {
         this.routineForm.patchValue({
           name: routine.name,
           description: routine.description || '',
+          tag: routine.tag || '',
           category: routine.level,
           difficulty: routine.level,
           icon: '',
@@ -279,6 +281,7 @@ export class RoutineEditorComponent implements OnInit {
         this.routineForm.patchValue({
           name: routine.name || '',
           description: routine.description || '',
+          tag: routine.tag || '',
           category: routine.category || '',
           difficulty: routine.difficulty || 'beginner',
           icon: routine.icon || '',

--- a/apps/frontend/src/app/components/routine-list.component.ts
+++ b/apps/frontend/src/app/components/routine-list.component.ts
@@ -27,6 +27,13 @@ export class RoutineListComponent implements OnInit {
     return this.routines.filter(r => r.visibility === 'user').length;
   }
 
+  private readonly FILTER_TAGS: Record<string, string[]> = {
+    'Quotidien': ['quotidien'],
+    'Bureau':    ['bureau'],
+    'Sport':     ['sport'],
+  };
+
+  // Fallback keyword matching for routines without a tag
   private readonly FILTER_KEYWORDS: Record<string, string[]> = {
     'Quotidien': ['quotidien', 'matin', 'soir', 'douce', 'réveil', 'lever', 'détente', 'relaxation'],
     'Bureau':    ['bureau', 'cervical', 'assis', 'ordinateur', 'poste', 'travail', 'express', 'siège'],
@@ -36,10 +43,13 @@ export class RoutineListComponent implements OnInit {
   filteredRoutines = computed(() => {
     const f = this.activeFilter();
     if (f === 'Mes routines') return this.routines.filter(r => r.visibility === 'user');
-    const keywords = this.FILTER_KEYWORDS[f];
-    if (!keywords) return this.routines;
+    const tags = this.FILTER_TAGS[f];
+    if (!tags) return this.routines;
+    const keywords = this.FILTER_KEYWORDS[f] ?? [];
     const text = (r: Routine) => `${r.name} ${r.description ?? ''}`.toLowerCase();
-    return this.routines.filter(r => keywords.some(kw => text(r).includes(kw)));
+    return this.routines.filter(r =>
+      r.tag ? tags.includes(r.tag) : keywords.some(kw => text(r).includes(kw))
+    );
   });
 
   constructor(

--- a/libs/shared/src/lib/models.ts
+++ b/libs/shared/src/lib/models.ts
@@ -9,6 +9,8 @@ export interface Step {
   }>;
 }
 
+export type RoutineTag = 'quotidien' | 'bureau' | 'sport' | 'mobilite' | 'respiration';
+
 export interface Routine {
   id: string;
   slug: string;
@@ -22,6 +24,7 @@ export interface Routine {
   version?: number;
   visibility?: 'builtIn' | 'user';
   ownerId?: string;
+  tag?: RoutineTag | string;
 }
 
 export interface UserSettings {

--- a/routines/bureau-5min.json
+++ b/routines/bureau-5min.json
@@ -2,6 +2,7 @@
     "id": "bureau-5min",
     "slug": "bureau-5min",
     "name": "Pause bureau",
+    "tag": "bureau",
     "duration": 5,
     "level": "Tous niveaux",
     "description": "Étirements rapides pour la nuque, épaules et dos.",

--- a/routines/douce-10min.json
+++ b/routines/douce-10min.json
@@ -2,6 +2,7 @@
     "id": "douce-10min",
     "slug": "douce-10min",
     "name": "Routine douce",
+    "tag": "quotidien",
     "duration": 10,
     "level": "Débutant",
     "description": "Mobilité douce et étirements pour soulager les tensions.",


### PR DESCRIPTION
## Résumé

- **Shared model** : nouveau type `RoutineTag` (`quotidien | bureau | sport | mobilite | respiration`) et champ `tag?` sur l'interface `Routine`
- **Backend** : champ `tag` dans le schéma Mongoose, les DTOs Create/Update
- **Seeds JSON** : `douce-10min` → `quotidien`, `bureau-5min` → `bureau`
- **Migration** : script `migrate-routine-tags.ts` à exécuter une fois en prod pour taguer les routines existantes
- **Frontend** : filtrage direct sur `routine.tag` (fallback sur les mots-clés si le tag est absent — rétrocompat)
- **Éditeur** : sélecteur « Tag » dans les pills de métadonnées

## Migration DB

```bash
npx ts-node apps/backend/src/scripts/migrate-routine-tags.ts
```

## Tests

- 316 tests frontend ✅
- 165 tests backend ✅

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)