### PR TITLE
fix(ui): aligner le bas des cartes routine

### DIFF
--- a/apps/frontend/src/app/components/home.component.scss
+++ b/apps/frontend/src/app/components/home.component.scss
@@ -192,6 +192,8 @@
   padding: 14px;
   cursor: pointer;
   transition: all 160ms ease;
+  display: flex;
+  flex-direction: column;
 
   &:hover {
     transform: translateY(-2px);
@@ -222,6 +224,8 @@
   gap: 4px;
   align-items: center;
   color: var(--ink-4);
+  margin-top: auto;
+  padding-top: 8px;
 
   svg {
     vertical-align: middle;

--- a/apps/frontend/src/app/components/routine-list.component.scss
+++ b/apps/frontend/src/app/components/routine-list.component.scss
@@ -128,7 +128,7 @@
 .card-desc {
   color: var(--ink-3);
   margin: 0;
-  min-height: 36px;
+  flex: 1;
 }
 
 .card-meta {
@@ -137,7 +137,6 @@
   font-size: 12px;
   color: var(--ink-4);
   align-items: center;
-  margin-top: 4px;
 }
 
 .card-meta-item {
@@ -154,7 +153,8 @@
 .card-actions {
   display: flex;
   gap: 8px;
-  margin-top: 4px;
+  margin-top: auto;
+  padding-top: 4px;
 }
 
 .card-btn-start {


### PR DESCRIPTION
## Summary

- Les cartes avec un titre sur deux lignes décalaient les boutons "Démarrer" et les métadonnées vers le bas, cassant l'alignement horizontal entre cartes.
- Fix : `margin-top: auto` sur `.card-actions` (page Routines) et `.mini-card-meta` (page Accueil) pour pousser le bas de chaque carte au même niveau.

## Fichiers modifiés

- `routine-list.component.scss` — `.card-actions` : `margin-top: auto`
- `home.component.scss` — `.routine-mini-card` : flex column + `.mini-card-meta` : `margin-top: auto`

## Test plan

- [ ] Vérifier l'alignement des boutons "Démarrer" sur la page Routines avec des titres courts et longs
- [ ] Vérifier l'alignement des métadonnées sur la page Accueil avec des mini-cartes de hauteurs différentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)